### PR TITLE
Use CARGO_BUILD_TARGET instead of plain TARGET variable

### DIFF
--- a/changeforest-r/src/Makevars.in
+++ b/changeforest-r/src/Makevars.in
@@ -1,6 +1,6 @@
-TARGET ?= @RUST_TARGET@
+CARGO_BUILD_TARGET ?= @RUST_TARGET@
 TARGET_DIR = ./rust/target
-LIBDIR = $(TARGET_DIR)/$(TARGET)/release
+LIBDIR = $(TARGET_DIR)/$(CARGO_BUILD_TARGET)/release
 STATLIB = $(LIBDIR)/libchangeforestr.a
 PKG_LIBS = -L$(LIBDIR) -lchangeforestr
 
@@ -18,7 +18,7 @@ $(STATLIB):
 		export CARGO_HOME=$(CARGOTMP); \
 	fi && \
 		export PATH="$(PATH):$(HOME)/.cargo/bin" && \
-		cargo build --target=$(TARGET) --lib --release --manifest-path=./rust/Cargo.toml --target-dir $(TARGET_DIR)
+		cargo build --target=$(CARGO_BUILD_TARGET) --lib --release --manifest-path=./rust/Cargo.toml --target-dir $(TARGET_DIR)
 	if [ "$(NOT_CRAN)" != "true" ]; then \
 		rm -Rf $(CARGOTMP) && \
 		rm -Rf $(LIBDIR)/build; \


### PR DESCRIPTION
To better align with a typical Rust cross-compilation setup. This avoids setting `TARGET` manually in the conda recipe.